### PR TITLE
Update README.md to use fabric/scripts/bootstrap.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ git checkout release-1.4
 
 Download the docker images
 ```
-./scripts/bootstrap.sh
+curl -sSL http://bit.ly/2ysbOFE | bash -s 
 ```
 
 ### Mount the EVM Chaincode and start the network


### PR DESCRIPTION
bootstrap.sh was removed from fabric-samples and the one from fabric needs to be run instead.